### PR TITLE
Fix version typo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "codestats-obsidian",
 	"name": "Code::Stats",
 	"version": "1.0.2",
-	"minAppVersion": "1.11.6",
+	"minAppVersion": "1.1.16",
 	"description": "Code::Stats (https://codestats.net) plugin for Obsidian (https://obsidian.md)",
 	"author": "MiskaMyasa",
 	"authorUrl": "https://github.com/Miskamyasa",


### PR DESCRIPTION

There is no v"1.11.6" of Obsidian (yet). Changed to v"1.1.16".

https://github.com/obsidianmd/obsidian-releases/releases